### PR TITLE
Give property "main" a string only

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -9,10 +9,7 @@
   ],
   "repository": "git://github.com/monterail/angular-mighty-datepicker.git",
   "description": "Angular based datepicker with mighty options",
-  "main": [
-    "build/angular-mighty-datepicker.js",
-    "build/angular-mighty-datepicker.css"
-  ],
+  "main": "build/angular-mighty-datepicker.js",
   "dependencies": {
     "angular": ">= 1.2",
     "angular-bindonce": "*",


### PR DESCRIPTION
npm fails to install this package when referencing it via a GitHub commit hash with the following error: 

"TypeError: Arguments to path.resolve must be strings"

As the "main" property of a bower.json is purely informational I suggest that it be changed to a string in order that the package can be used through npm.