### PR TITLE
Some moment functions require greater version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
   ],
   "dependencies": {
     "angular": ">= 1.2",
-    "moment": ">= 2.6.0",
+    "moment": ">= 2.10.7",
     "moment-range": "~1.0.1"
   },
   "license": "MIT",


### PR DESCRIPTION
When using the library with moment 2.6.0 (as being the minimum version), an exception is being thrown due to missing moment functions.

According to moment's documentation (https://momentjs.com/docs/#/query/is-same-or-after/), the required function was introduced in version 2.10.7. Therefor I'm updating the dependencies.